### PR TITLE
Deleting translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Saved translation files now end in a newline
+- Translations removed from the source will now be removed from all destinations
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Switched the codebase to typescript, fixes #5
 - Changed the format of the `destinationLanguages` from an array of strings `"en"` to an array of objects: `{ "code": "en"}`
+- Errors thrown while executing a changeset will error and exit, instead of throwing unhandled promise exception warnings
 
 ## [0.3.2] - 2020-04-27
 

--- a/src/change-executor.ts
+++ b/src/change-executor.ts
@@ -15,10 +15,9 @@ class ChangeExecutor {
   }
 
   async execute(change: ChangesetItem) {
-    // TODO: throwing an error here should end the process, not through unhandled promise error and keep going
     switch (change.op) {
     case 'remove':
-      this.executeRemoval(change);
+      await this.executeRemoval(change);
       break;
 
     case 'translate':

--- a/src/change-executor.ts
+++ b/src/change-executor.ts
@@ -26,9 +26,33 @@ class ChangeExecutor {
     }
   }
 
-  async executeRemoval(_change: ChangesetRemoveOperationItem) {
-    // TODO: implement
-    throw new Error('removal is not implemented yet');
+  async executeRemoval(change: ChangesetRemoveOperationItem) {
+    // TODO: Move this back out of this class and use a start and finish event instead
+    // That way we can switch between showing each and updating a progress bar
+    this.logger(`Removing key '${change.path}' from lang '${change.translation.lang}'`);
+
+    let data = change.translation.file.data;
+    let path = change.path.split('/').splice(1);
+
+    // Follow the path into the destination translation's data,
+    // until we can finally set the translated text.
+    path.reduce((current, key, index) => {
+      let last = index === path.length - 1;
+
+      if (last) {
+        delete current[key];
+      } else {
+        if (typeof current[key] !== 'object') {
+          current[key] = {};
+        }
+        // We're ensuring this is an object here,
+        // but we have to encourage TypeScript to understand the correct type.
+        return current[key] as TranslationData;
+      }
+
+      // We don't do anything with the final return value, but this makes TypeScript happy.
+      return current;
+    }, data);
   }
 
   async executeTranslation(change: ChangesetTranslateOperationItem) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ class I18NCloudTranslator extends Command {
     let translator = new GoogleTranslator(config);
 
     // Setup the executor and the rate-limited scheduler
-    // This ensures we don't hit APIs too fast and hit rate limites
+    // This ensures we don't hit APIs too fast and hit rate limits
     let executor = new ChangeExecutor(translator, this.log);
     let limiter = new Bottleneck({
       maxConcurrent: 1,
@@ -87,7 +87,11 @@ class I18NCloudTranslator extends Command {
 
     // Schedule the work!
     let executions = changeset.map(change => {
-      return limiter.schedule(() => executor.execute(change));
+      return limiter.schedule(() => {
+        return executor.execute(change).catch(error => {
+          this.error(error);
+        });
+      });
     });
     await Promise.all(executions);
 


### PR DESCRIPTION
When you delete items from the source translations, we'll now properly process the `ChangesetRemoveOperationItem` and remove those items from all destination translations.

We also now handle errors occurring during processing by throwing an error and exiting the process, instead of spamming unhandled promise exception warnings.