### PR TITLE
Allow Placeholders In Translations

### DIFF
--- a/src/change-executor.ts
+++ b/src/change-executor.ts
@@ -64,14 +64,14 @@ class ChangeExecutor {
     this.logger(`Translating key '${change.path}' to lang '${change.translation.lang}'`);
 
     let sourceText = change.sourceTranslation;
-    
+
     const hasPlaceholders = PLACEHOLDER_REGEX_PRE.test(sourceText);
 
     if (hasPlaceholders) {
       sourceText = sourceText.replace(PLACEHOLDER_REGEX_PRE, '<span class="notranslate">$1</span>');
     }
 
-    let [translatedText] = await this.translator.translate(change.sourceTranslation, change.translation.lang);
+    let [translatedText] = await this.translator.translate(sourceText, change.translation.lang);
 
     if (hasPlaceholders) {
       translatedText = translatedText.replace(PLACEHOLDER_REGEX_POST, '{$1}');


### PR DESCRIPTION
Allows the usage of %{} as a way to partially exclude translations by changing it into a <span> tag with the class "notranslate" which apparently google respects.

Used %{} because it has the added benefit of being able to make use of the formatting in [Vue I18n](https://kazupon.github.io/vue-i18n/guide/formatting.html#support-ruby-on-rails-i18n-format)

Not gonna lie, I didn't know how to actually run and test this locally on Windows but the change is small enough so hopefully it'll at least help with the feature.